### PR TITLE
CR and trailing space

### DIFF
--- a/regression/examples/AtomicBakeryG.tla
+++ b/regression/examples/AtomicBakeryG.tla
@@ -281,7 +281,7 @@ THEOREM TypeOKInvariant ==
                                 ELSE /\ TRUE
                                      /\ max' = max
                       /\ pc' = [pc EXCEPT ![self] = "p2"]
-                      /\ num' = num /\ flag' = flag /\ nxt' = nxt 
+                      /\ num' = num /\ flag' = flag /\ nxt' = nxt
         BY <1>4, <3>2
       <4>2 CASE j = self
         BY <2>1, <4>1, <4>2, SimplifyAndSolve
@@ -331,7 +331,7 @@ THEOREM TypeOKInvariant ==
         /\ pc' = [pc EXCEPT ![self] = "p5"]
         /\ UNCHANGED << num, flag, max, nxt >>
     BY <1>8 DEF p6
-  <2>2. QED 
+  <2>2. QED
     BY <2>1, SimplifyAndSolve
 
 <1>9. CASE p7(self)
@@ -373,7 +373,7 @@ THEOREM Inv => MutualExclusion
 (* The following lemma asserts that the predicate After(i,j) is preserved  *)
 (* if none of the state components change in terms of which it is defined. *)
 (***************************************************************************)
-THEOREM AfterPrime == 
+THEOREM AfterPrime ==
   ASSUME NEW i, NEW j,
          After(i,j),
          UNCHANGED <<num[i], num[j], pc[i], unread[i], max[i]>>

--- a/regression/examples/AtomicBakeryGInitialized.tla
+++ b/regression/examples/AtomicBakeryGInitialized.tla
@@ -21,8 +21,8 @@ ASSUME PsubsetNat == P \subseteq Nat
 variable num = [i \in P |-> 0], flag = [i \in P |-> FALSE];
 
 process (p \in P)
-  variables unread \in SUBSET P, 
-            max \in Nat, 
+  variables unread \in SUBSET P,
+            max \in Nat,
             nxt \in P
 {
 p1: while (TRUE) {
@@ -269,7 +269,7 @@ THEOREM TypeOKInvariant ==
                           THEN [max EXCEPT ![self] = num[k]]
                           ELSE max
                 /\ pc' = [pc EXCEPT ![self] = "p2"]
-                /\ num' = num /\ flag' = flag /\ nxt' = nxt 
+                /\ num' = num /\ flag' = flag /\ nxt' = nxt
       BY <1>2, <2>2 DEF p2
     <3>2. QED
       BY <3>1
@@ -319,7 +319,7 @@ BY DEF Inv, IInv, MutualExclusion, After
 (* The following lemma asserts that the predicate After(i,j) is preserved  *)
 (* if none of the state components change in terms of which it is defined. *)
 (***************************************************************************)
-THEOREM AfterPrime == 
+THEOREM AfterPrime ==
   ASSUME NEW i, NEW j,
          After(i,j),
          UNCHANGED <<num[i], num[j], pc[i], unread[i], max[i]>>
@@ -586,7 +586,7 @@ THEOREM Inv /\ Next => Inv'
          <6>1. num[nxt[self]] > num[self]
            BY <5>1  (* from definition of p6 *)
          <6>2. num[self] >= num[nxt[self]]
-           BY <4>2, <5>1, GTAxiom, PsubsetNat DEF GG  
+           BY <4>2, <5>1, GTAxiom, PsubsetNat DEF GG
               (* from definition of GG and assumptions for i and j *)
          <6>3. QED
            BY <6>1, <6>2, Transitivity2, GTAxiom

--- a/regression/examples/data/SequencesTheorems.tla
+++ b/regression/examples/data/SequencesTheorems.tla
@@ -297,7 +297,7 @@ THEOREM RemoveSeq ==
                       NEW seq \in Seq(S),
                       NEW i \in 1..Len(seq)
                PROVE   Remove(i, seq) \in Seq(S)
-  BY <1>1 
+  BY <1>1
 <1>2. /\ Len(seq) \in Nat
       /\ seq \in [1..Len(seq) -> S]
   BY LenAxiom

--- a/regression/misc/Bug08_11_20.tla
+++ b/regression/misc/Bug08_11_20.tla
@@ -1,8 +1,8 @@
------------------------------- MODULE Bug08_11_20 -------------------------- 
+------------------------------ MODULE Bug08_11_20 --------------------------
 
 Not(i) == IF i = 0 THEN 1 ELSE 0
 
-Strings == 
+Strings ==
 /\ "a0" # "a1"
 /\ "a0" # "a2"
 /\ "a0" # "a3"
@@ -24,13 +24,13 @@ Strings ==
 --algorithm Peterson {
    variables flag = [i \in {0, 1} |-> FALSE], turn = 0;
    process (proc \in {0,1}) {
-     a0: while (TRUE) { 
-     a1:   flag[self] := TRUE; 
-     a2:   turn := Not(self);       
+     a0: while (TRUE) {
+     a1:   flag[self] := TRUE;
+     a2:   turn := Not(self);
      a3:   while (flag[Not(self)] /\ turn = Not(self)) {
              skip };
-     cs:   skip;  \* critical section   
-     a4:   flag[self] := FALSE;            
+     cs:   skip;  \* critical section
+     a4:   flag[self] := FALSE;
      } \* end while
     } \* end process
   }
@@ -109,7 +109,7 @@ TypeOK == /\ pc \in [{0,1} -> {"a0", "a1", "a2", "a3", "cs", "a4"}]
 
 II(i) ==
        /\ (pc[i] \in {"a2", "a3", "cs", "a4"} ) => flag[i]
-            
+
        /\ (pc[i] \in {"cs", "a4"}) => /\ pc[Not(i)] \notin {"cs", "a4"}
                                       /\ (pc[Not(i)] = "a3") => (turn = i)
 
@@ -123,8 +123,8 @@ TypeOK_p == /\ pc_p \in [{0,1} -> {"a0", "a1", "a2", "a3", "cs", "a4"}]
 
 
 II_p(i) ==  /\ (pc_p[i] \in {"a2", "a3", "cs", "a4"} ) => flag_p[i]
-            
-            /\ (pc_p[i] \in {"cs", "a4"}) => 
+
+            /\ (pc_p[i] \in {"cs", "a4"}) =>
                     /\ pc_p[Not(i)] \notin {"cs", "a4"}
                     /\ (pc_p[Not(i)] = "a3") => (turn_p = i)
 
@@ -137,10 +137,10 @@ ISpec == (TypeOK /\ I) /\ [][Next]_vars
 THEOREM Inductive == Strings /\ TypeOK /\ I /\ Next => I_p
 \*  <1>  USE DEF Strings
   <1>1. ASSUME Strings,
-               TypeOK, 
+               TypeOK,
                I,
                NEW i \in {0,1},
-               proc(i) 
+               proc(i)
         PROVE  I_p
 
     <2>1. ASSUME NEW j \in {0, 1}

--- a/regression/misc/Bug08_11_20a.tla
+++ b/regression/misc/Bug08_11_20a.tla
@@ -1,4 +1,4 @@
--------------------------- MODULE Bug08_11_20a --------------------------- 
+-------------------------- MODULE Bug08_11_20a ---------------------------
 
 (***************************************************************************)
 (* Something weird is going on here.  Go down to the proof at the end of   *)
@@ -20,7 +20,7 @@
 
 Not(i) == IF i = 0 THEN 1 ELSE 0
 
-Strings == 
+Strings ==
 /\ "a0" # "a1"
 /\ "a0" # "a2"
 /\ "a0" # "a3"
@@ -99,7 +99,7 @@ TypeOK == /\ pc \in [{0,1} -> {"a0", "a1", "a2", "a3", "cs", "a4"}]
 
 II(i) ==
        /\ (pc[i] \in {"a2", "a3", "cs", "a4"} ) => flag[i]
-            
+
        /\ (pc[i] \in {"cs", "a4"}) => /\ pc[Not(i)] \notin {"cs", "a4"}
                                       /\ (pc[Not(i)] = "a3") => (turn = i)
 
@@ -113,8 +113,8 @@ TypeOK_p == /\ pc_p \in [{0,1} -> {"a0", "a1", "a2", "a3", "cs", "a4"}]
 
 
 II_p(i) ==  /\ (pc_p[i] \in {"a2", "a3", "cs", "a4"} ) => flag_p[i]
-            
-            /\ (pc_p[i] \in {"cs", "a4"}) => 
+
+            /\ (pc_p[i] \in {"cs", "a4"}) =>
                   /\ pc_p[Not(i)] \notin {"cs", "a4"}
                   /\ (pc_p[Not(i)] = "a3") => (turn_p = i)
 

--- a/regression/misc/test5.tla
+++ b/regression/misc/test5.tla
@@ -4,7 +4,7 @@
 
 (*******************  the following is proved
    THEOREM (\E i : P(i)) => Q
-   <1>1. ASSUME NEW i 
+   <1>1. ASSUME NEW i
          PROVE P(i) => Q
    <1>2. QED
          BY <1>1
@@ -17,10 +17,10 @@
          BY <1>1
 **********************)
 
-THEOREM  (~ (\E i : P(i))) <=> (\A i : ~P(i)) 
+THEOREM  (~ (\E i : P(i))) <=> (\A i : ~P(i))
 OBVIOUS
 ==============
-THEOREM  (~ (\E i \in {0, 1} : P(i))) <=> (\A i \in {0, 1} : ~P(i)) 
+THEOREM  (~ (\E i \in {0, 1} : P(i))) <=> (\A i \in {0, 1} : ~P(i))
 OBVIOUS
 =================
 
@@ -43,9 +43,9 @@ OBVIOUS
 \*      OBVIOUS
    <1>3. SUFFICES \A i \in {0, 1} : P(i) => Q
 \*      OBVIOUS
-   <1>4. ASSUME NEW i \in {0,1} 
+   <1>4. ASSUME NEW i \in {0,1}
          PROVE  P(i) => Q
    <1>5. QED
-\*      BY <1>4 
+\*      BY <1>4
 
    ================================================

--- a/regression/peterson/MutexQ.tla
+++ b/regression/peterson/MutexQ.tla
@@ -1,8 +1,8 @@
--------------------------------- MODULE MutexQ ------------------------------ 
+-------------------------------- MODULE MutexQ ------------------------------
 
 CONSTANTS x, y, pcx, pcy, xp, yp, pcxp, pcyp, q0, q1, q2
 
-ASSUME Arith == /\ q1 # q0 
+ASSUME Arith == /\ q1 # q0
                 /\ q2 # q1
                 /\ q2 # q0
 
@@ -37,7 +37,7 @@ Next == \/ /\ pcx = q0
            /\ yp = y
            /\ pcxp = pcx
            /\ pcyp = pcy
-    
+
 
 Inv == /\ x \in BOOLEAN
        /\ y \in BOOLEAN
@@ -51,7 +51,7 @@ Inv == /\ x \in BOOLEAN
           => y = TRUE
        /\ ~ (pcx = q2 /\ pcy = q2)
 
-Invp == 
+Invp ==
        /\ xp \in BOOLEAN
        /\ yp \in BOOLEAN
        /\ pcxp \in {q0, q1, q2}
@@ -66,7 +66,7 @@ Invp ==
 
 
 THEOREM Inv /\ Next => Invp
-PROOF 
+PROOF
 <1>1. USE Arith
 <1>2. QED
       BY Arith DEFS Inv, Next, Invp

--- a/test/Makefile
+++ b/test/Makefile
@@ -56,7 +56,7 @@ coqscript: basics.vo
                       >tmp_test.v \
 	     && (echo $$i '-> coqc' | tr -d '\n'; \
 	         coqc -I .. tmp_test.v); then \
-	    echo '' | tr -d '\n'; \
+	    printf '\r'; \
 	  else \
 	    echo $$i '>>> TEST FAILED <<<' ; \
 	    exit 3 ; \
@@ -75,7 +75,7 @@ coqterm: basics.vo
                       >tmp_test.v \
 	     && (echo $$i '-> coqc' | tr -d '\n'; \
 	         coqc -I .. tmp_test.v); then \
-	    echo '' | tr -d '\n'; \
+	    printf '\r'; \
 	  else \
 	    echo $$i '>>> TEST FAILED <<<' ; \
 	    exit 3 ; \

--- a/www/index.html
+++ b/www/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"><html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"><head><meta http-equiv="content-type" content="application/xhtml+xml; charset=utf-8" />
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"><html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"><head><meta http-equiv="content-type" content="application/xhtml+xml; charset=utf-8" />
 
     <title>The Zenon automatic theorem prover</title>
     
@@ -41,7 +41,7 @@
 
     <ul>
 
-      <li>version 0.8.2 (2016-06-06): <a href="zenon-0.8.2.tar.gz">gzip</a></li><li>version 0.8.1 (2016-05-31): <a href="zenon-0.8.1.tar.gz">gzip</a></li>
+      <li>version 0.8.2 (2016-06-06): <a href="zenon-0.8.2.tar.gz">gzip</a></li><li>version 0.8.1 (2016-05-31): <a href="zenon-0.8.1.tar.gz">gzip</a></li>
       <li>version 0.8.0 (2014-10-21): <a href="zenon-0.8.0.tar.gz">gzip</a>
       </li><li>version 0.7.1 (2012-05-09): <a href="zenon-0.7.1.tar.gz">gzip</a>;
         <a href="zenon-0.7.1.tar.xz">xzip</a>


### PR DESCRIPTION
These changes remove trailing ` `, `\r`, and replace literal `\r` characters with the escape sequence `\r`.